### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ to close any of the currently opened sockets.
 Getting started
 ---------------
 
- *  [Read the guide](http://ninenines.eu/docs/en/ranch/HEAD/guide/introduction)
+ *  [Read the guide](https://ninenines.eu/docs/en/ranch/HEAD/guide/introduction)
  *  Look at the examples in the `examples/` directory
  *  Build API documentation with `make docs`; open `doc/index.html`
 
@@ -30,5 +30,5 @@ Support
 -------
 
  *  Official IRC Channel: #ninenines on irc.freenode.net
- *  [Mailing Lists](http://lists.ninenines.eu)
- *  [Commercial Support](http://ninenines.eu/support)
+ *  [Mailing Lists](https://lists.ninenines.eu)
+ *  [Commercial Support](https://ninenines.eu/support)

--- a/guide/ssl_auth.md
+++ b/guide/ssl_auth.md
@@ -31,7 +31,7 @@ Following are the steps you need to take to create a CAcert.org
 account, generate a certificate and install it in your favorite
 browser.
 
- *  Open [CAcert.org](http://cacert.org) in your favorite browser
+ *  Open [CAcert.org](http://www.cacert.org) in your favorite browser
  *  Root Certificate link: install both certificates
  *  Join (Register an account)
  *  Verify your account (check your email inbox!)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://cacert.org (302) with 1 occurrences could not be migrated:  
   ([https](https://cacert.org) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://lists.ninenines.eu (UnknownHostException) with 1 occurrences migrated to:  
  https://lists.ninenines.eu ([https](https://lists.ninenines.eu) result UnknownHostException).
* http://ninenines.eu/docs/en/ranch/HEAD/guide/introduction (301) with 1 occurrences migrated to:  
  https://ninenines.eu/docs/en/ranch/HEAD/guide/introduction ([https](https://ninenines.eu/docs/en/ranch/HEAD/guide/introduction) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://ninenines.eu/support with 1 occurrences migrated to:  
  https://ninenines.eu/support ([https](https://ninenines.eu/support) result 301).